### PR TITLE
Fix docker template

### DIFF
--- a/challenge_templates/pwn/Dockerfile
+++ b/challenge_templates/pwn/Dockerfile
@@ -22,7 +22,7 @@ ADD challenge/flag /flag
 ADD challenge/challenge /home/ctf/challenge
 
 # Set some proper permissions
-RUN chown -R root:ctf /home/ctf
+RUN chown -R root:ctf /home/ctf /flag
 RUN chmod 750 /home/ctf/challenge
 RUN chmod 750 /home/ctf/run_challenge.sh
 RUN chmod 440 /flag

--- a/challenge_templates/pwn/docker-compose.yml
+++ b/challenge_templates/pwn/docker-compose.yml
@@ -7,3 +7,4 @@ services:
     ports:
       - "31337:31337" # exposed:local
     entrypoint: /etc/run_xinetd.sh
+    read_only: true


### PR DESCRIPTION
The flag wasn't readable by the ctf user, also default to making the entire root volume read-only for pwns