### PR TITLE
Fix uncomfortable colors for URLs and badges on completed challenges

### DIFF
--- a/ctf_framework/templates/challenge/index.html
+++ b/ctf_framework/templates/challenge/index.html
@@ -35,7 +35,7 @@
 
                     {# User completed challenge #}
                     {% if challenge.is_completed %}
-                        <div class="card-body bg-success text-white">
+                        <div class="card-body bg-success text-white link-success">
                     {% else %}
                         <div class="card-body">
                     {% endif %}
@@ -52,7 +52,7 @@
 
                         {# Challenge is active #}
                         {% if challenge.info.is_active %}
-                            <span class="float-right badge badge-info">
+                            <span class="float-right badge badge-info border border-white">
                       {{ challenge.info.point_value }} pts
                     </span>
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2,3 +2,7 @@
   width: 75vw;
   margin: 0 auto;
 }
+
+.link-success a {
+  color: white;
+}


### PR DESCRIPTION
When solving a challenge, the green background color doesn't mix well with the point badge and the URLs. Updated the colors a bit (view before and after screenshots).

Before : 

<img width="366" alt="before" src="https://user-images.githubusercontent.com/6225588/44240442-1be0a280-a18c-11e8-8827-075436ba23b7.png">

After : 

<img width="410" alt="after" src="https://user-images.githubusercontent.com/6225588/44240445-1daa6600-a18c-11e8-8629-4f68ebc4683f.png">

