### PR TITLE
Fix sorting to take last validated challenge into account

### DIFF
--- a/ctf_framework/templates/misc/home.html
+++ b/ctf_framework/templates/misc/home.html
@@ -5,19 +5,21 @@
     <table class="table table-bordered">
       <tr>
         <th>Users</th>
+        <th>Latest Validation</th>
         <th>Score</th>
       </tr>
+
       {% for user in users %}
       <tr>
         <td>
           <a href="{% url 'ctf_framework:profile#show' user.id %}">{{ user }}</a>
-          {% if user.active_title %}
-            |
+          {% if user.active_title %}|
             <span class="badge badge-dark">
                 {{ user.active_title }}
             </span>
           {% endif %}
         </td>
+        <td>{{ user.last_solve_time|date:"Y-m-d H:i:s" }}</td>
         <td>{{ user.get_score }}</td>
       </tr>
       {% endfor %}

--- a/ctf_framework/views/home.py
+++ b/ctf_framework/views/home.py
@@ -8,7 +8,7 @@ def index(request):
     challenges = Challenge.objects.all()
 
     # Order users by score
-    sorted_users = sorted(users, key=lambda u: -u.get_score())
+    sorted_users = sorted(users, key=lambda u: (-u.get_score(), u.last_solve_time))
     context = {
         "users": sorted_users,
         "challenges": challenges


### PR DESCRIPTION
Leaderboard sorting used to be performed based on user score and user ID. This issue has been fixed to take the last validation time into account.

<img width="1003" alt="new_leaderboard" src="https://user-images.githubusercontent.com/6225588/44241376-86e0a800-a191-11e8-82a8-33002ff60877.png">
